### PR TITLE
Add Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.png
+dragn-emoji.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+SVGS := $(wildcard *.svg)
+PNGS := $(SVGS:%.svg=%.png)
+
+.PHONY: clean
+
+dragn-emoji.tar.gz: $(PNGS)
+	tar -c $? | gzip > $@
+
+%.nooptim.png: %.svg
+	magick convert -background none -geometry 256x256 $< $@
+
+%.png: %.nooptim.png
+	oxipng -o max --out $@ $<
+
+clean:
+	find . -maxdepth 1 -name '*.png' -delete
+	rm -f dragn-emoji.tar.gz


### PR DESCRIPTION
This makefile generates PNG versions and an archive that can be imported directly into Mastodon. It requires imagemagick and oxipng.